### PR TITLE
INTERLOK-3187 Add references to repo and README

### DIFF
--- a/interlok-elastic-common/build.gradle
+++ b/interlok-elastic-common/build.gradle
@@ -49,6 +49,8 @@ publishing {
             properties.appendNode("target", "3.9.1+")
             properties.appendNode("license", "false")
             properties.appendNode("tags", "elastic,elasticsearch")
+            properties.appendNode("readme", "https://github.com/adaptris/interlok-elastic/raw/develop/README.md")
+            properties.appendNode("repository", "https://github.com/adaptris/interlok-elastic")
           }
       }
   }

--- a/interlok-elastic-rest/build.gradle
+++ b/interlok-elastic-rest/build.gradle
@@ -57,6 +57,8 @@ publishing {
             properties.appendNode("target", "3.9.1+")
             properties.appendNode("license", "false")
             properties.appendNode("tags", "elastic,elasticsearch")
+            properties.appendNode("readme", "https://github.com/adaptris/interlok-elastic/raw/develop/README.md")
+            properties.appendNode("repository", "https://github.com/adaptris/interlok-elastic")
           }
       }
   }


### PR DESCRIPTION
## Motivation

Give the UI the ability to point to the optional component repository.

## Modification

Update the gradle.build files to include references to README and Git repository in the POM.

## Result

The information will eventually be available in the UI.

## Testing

Check that the new repository property exists in the POM file after running `gradle generatePomFileForMavenJavaPublication`.