### PR TITLE
feature/INTERLOK-3749 - Switch dependency from Apache Commons CSV to SuperCSV

### DIFF
--- a/interlok-elastic-common/build.gradle
+++ b/interlok-elastic-common/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   // INTERLOK-3559 since we removed apache-csv out of interlok-csv it's
   // a bigger deal to remove it out of elastic
   compile("org.apache.commons:commons-csv:1.8")
+  compile("net.sf.supercsv:super-csv:2.4.0")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilder.java
@@ -20,7 +20,6 @@ import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.elastic.csv.BasicFormatBuilder;
 import com.adaptris.core.elastic.csv.FormatBuilder;
 import com.adaptris.csv.PreferenceBuilder;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -71,9 +70,10 @@ public class CSVDocumentBuilder extends CSVDocumentBuilderImpl {
   private Boolean useHeaderRecord;
 
   public CSVDocumentBuilder() {
-    this(new BasicFormatBuilder());
+    super();
   }
 
+  @Deprecated
   public CSVDocumentBuilder(FormatBuilder f) {
     super();
     setFormat(f);
@@ -82,7 +82,6 @@ public class CSVDocumentBuilder extends CSVDocumentBuilderImpl {
   public CSVDocumentBuilder(PreferenceBuilder p) {
     super();
     setPreference(p);
-    setUseSuperCsv(true);
   }
 
   public CSVDocumentBuilder withUseHeaderRecord(Boolean b) {

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilder.java
@@ -95,8 +95,9 @@ public class CSVDocumentBuilder extends CSVDocumentBuilderImpl {
   }
 
   @Override
+  @Deprecated
   protected CSVDocumentWrapper buildWrapper(CSVParser parser, AdaptrisMessage msg) {
-    return new MyWrapper(parser);
+    return new ApacheWrapper(parser);
   }
 
   @Override
@@ -158,10 +159,11 @@ public class CSVDocumentBuilder extends CSVDocumentBuilderImpl {
     }
   }
 
-  private class MyWrapper extends CSVDocumentWrapper {
+  @Deprecated
+  private class ApacheWrapper extends CSVDocumentWrapper {
     private List<String> headers = new ArrayList<>();
 
-    public MyWrapper(CSVParser p) {
+    public ApacheWrapper(CSVParser p) {
       super(p);
       if (useHeaderRecord()) {
         headers = buildHeaders(csvIterator.next());

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilderImpl.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilderImpl.java
@@ -30,6 +30,7 @@ import com.adaptris.csv.BasicPreferenceBuilder;
 import com.adaptris.csv.PreferenceBuilder;
 import com.adaptris.interlok.util.CloseableIterable;
 import com.adaptris.util.NumberUtils;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -64,12 +65,12 @@ public abstract class CSVDocumentBuilderImpl implements ElasticDocumentBuilder {
    * Defaults to {@link BasicFormatBuilder} by default.
    * </p>
    */
-  @NotNull
   @AutoPopulated
   @Valid
   @Getter
   @Setter
-  @NonNull
+  @Deprecated
+  @ConfigDeprecated(removalVersion = "x.y.z", message = "Use 'preference' instead", groups = Deprecated.class)
   private FormatBuilder format;
 
   /**
@@ -79,6 +80,8 @@ public abstract class CSVDocumentBuilderImpl implements ElasticDocumentBuilder {
    * </p>
    */
   @AutoPopulated
+//  @NotNull
+//  @NonNull
   @Valid
   @Getter
   @Setter
@@ -220,19 +223,23 @@ public abstract class CSVDocumentBuilderImpl implements ElasticDocumentBuilder {
     return result;
   }
 
+  @Deprecated
   protected abstract CSVDocumentWrapper buildWrapper(CSVParser parser, AdaptrisMessage msg) throws Exception;
 
   protected abstract CSVDocumentWrapper buildWrapper(CsvListReader reader, AdaptrisMessage message) throws Exception;
 
 
   protected abstract class CSVDocumentWrapper implements CloseableIterable<DocumentWrapper>, Iterator {
+    @Deprecated
     protected CSVParser parser;
+    @Deprecated
     protected Iterator<CSVRecord> csvIterator;
 
     protected CsvListReader reader;
 
     private boolean iteratorInvoked = false;
 
+    @Deprecated
     public CSVDocumentWrapper(CSVParser p) {
       parser = p;
       csvIterator = p.iterator();

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilderImpl.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilderImpl.java
@@ -70,7 +70,7 @@ public abstract class CSVDocumentBuilderImpl implements ElasticDocumentBuilder {
   @Getter
   @Setter
   @Deprecated
-  @ConfigDeprecated(removalVersion = "x.y.z", message = "Use 'preference' instead", groups = Deprecated.class)
+  @ConfigDeprecated(/*removalVersion = "x.y.z",*/ message = "Use 'preference' instead", groups = Deprecated.class)
   private FormatBuilder format;
 
   /**

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVWithGeoPointBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVWithGeoPointBuilder.java
@@ -145,10 +145,11 @@ public class CSVWithGeoPointBuilder extends CSVDocumentBuilderImpl {
   }
 
   @Override
+  @Deprecated
   protected CSVDocumentWrapper buildWrapper(CSVParser parser, AdaptrisMessage msg) throws Exception {
     Set<String> latitudeFieldNames = new HashSet<String>(Arrays.asList(latitudeFieldNames().toLowerCase().split(",")));
     Set<String> longitudeFieldNames = new HashSet<String>(Arrays.asList(longitudeFieldNames().toLowerCase().split(",")));
-    return new MyWrapper(latitudeFieldNames, longitudeFieldNames, parser);
+    return new ApacheWrapper(latitudeFieldNames, longitudeFieldNames, parser);
   }
 
   @Override
@@ -218,11 +219,12 @@ public class CSVWithGeoPointBuilder extends CSVDocumentBuilderImpl {
     }
   }
 
-  private class MyWrapper extends CSVDocumentWrapper {
+  @Deprecated
+  private class ApacheWrapper extends CSVDocumentWrapper {
     private List<String> headers = new ArrayList<>();
     private LatLongHandler latLong;
 
-    public MyWrapper(Set<String> latitudeFieldNames, Set<String> longitudeFieldNames, CSVParser p) {
+    public ApacheWrapper(Set<String> latitudeFieldNames, Set<String> longitudeFieldNames, CSVParser p) {
       super(p);
       headers = buildHeaders(csvIterator.next());
       latLong = new LatLongHandler(latitudeFieldNames, longitudeFieldNames, headers);

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVWithGeoPointBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVWithGeoPointBuilder.java
@@ -20,7 +20,6 @@ import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.elastic.csv.BasicFormatBuilder;
 import com.adaptris.core.elastic.csv.FormatBuilder;
 import com.adaptris.csv.PreferenceBuilder;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -103,9 +102,10 @@ public class CSVWithGeoPointBuilder extends CSVDocumentBuilderImpl {
   private String locationFieldName;
 
   public CSVWithGeoPointBuilder() {
-    this(new BasicFormatBuilder());
+    super();
   }
 
+  @Deprecated
   public CSVWithGeoPointBuilder(FormatBuilder f) {
     super();
     setFormat(f);
@@ -114,7 +114,6 @@ public class CSVWithGeoPointBuilder extends CSVDocumentBuilderImpl {
   public CSVWithGeoPointBuilder(PreferenceBuilder p) {
     super();
     setPreference(p);
-    setUseSuperCsv(true);
   }
 
   public CSVWithGeoPointBuilder withLatitudeFieldNames(String s) {

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVWithGeoPointBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVWithGeoPointBuilder.java
@@ -16,13 +16,16 @@
 
 package com.adaptris.core.elastic;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.elastic.csv.BasicFormatBuilder;
+import com.adaptris.core.elastic.csv.FormatBuilder;
+import com.adaptris.csv.PreferenceBuilder;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -30,15 +33,16 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.elastic.csv.BasicFormatBuilder;
-import com.adaptris.core.elastic.csv.FormatBuilder;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import lombok.Getter;
-import lombok.Setter;
+import org.supercsv.io.CsvListReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 /**
  * Builds a document for elastic search.
@@ -107,6 +111,12 @@ public class CSVWithGeoPointBuilder extends CSVDocumentBuilderImpl {
     setFormat(f);
   }
 
+  public CSVWithGeoPointBuilder(PreferenceBuilder p) {
+    super();
+    setPreference(p);
+    setUseSuperCsv(true);
+  }
+
   public CSVWithGeoPointBuilder withLatitudeFieldNames(String s) {
     setLatitudeFieldNames(s);
     return this;
@@ -139,6 +149,73 @@ public class CSVWithGeoPointBuilder extends CSVDocumentBuilderImpl {
     Set<String> latitudeFieldNames = new HashSet<String>(Arrays.asList(latitudeFieldNames().toLowerCase().split(",")));
     Set<String> longitudeFieldNames = new HashSet<String>(Arrays.asList(longitudeFieldNames().toLowerCase().split(",")));
     return new MyWrapper(latitudeFieldNames, longitudeFieldNames, parser);
+  }
+
+  @Override
+  protected CSVDocumentWrapper buildWrapper(CsvListReader reader, AdaptrisMessage message) throws Exception {
+    Set<String> latitudeFieldNames = new HashSet<String>(Arrays.asList(latitudeFieldNames().toLowerCase().split(",")));
+    Set<String> longitudeFieldNames = new HashSet<String>(Arrays.asList(longitudeFieldNames().toLowerCase().split(",")));
+    return new SuperWrapper(latitudeFieldNames, longitudeFieldNames, reader);
+  }
+
+  private class SuperWrapper extends CSVDocumentWrapper {
+    private String[] headers = new String[0];
+    private LatLongHandler latLong;
+    private List<String> next;
+
+    public SuperWrapper(Set<String> latitudeFieldNames, Set<String> longitudeFieldNames, CsvListReader reader) {
+      super(reader);
+      headers = buildHeaders(reader);
+      latLong = new LatLongHandler(latitudeFieldNames, longitudeFieldNames, headers);
+    }
+
+    @Override
+    public DocumentWrapper next() {
+      DocumentWrapper result = null;
+      try {
+        List<String> row = next;
+        next = null;
+        if (row != null) {
+          int idField = 0;
+          if (uniqueIdField() <= row.size()) {
+            idField = uniqueIdField();
+          }
+          else {
+            throw new Exception("unique-id field > number of fields in record");
+          }
+          String uniqueId = row.get(idField);
+          XContentBuilder builder = jsonBuilder();
+          builder.startObject();
+
+          addTimestamp(builder);
+
+          for (int i = 0; i < row.size(); i++) {
+            String fieldName = headers[i];
+            String data = row.get(i);
+            if (!latLong.isLatOrLong(fieldName)) {
+              builder.field(getFieldNameMapper().map(fieldName), new Text(data != null ? data : ""));
+            }
+          }
+          latLong.addLatLong(builder, row);
+          builder.endObject();
+          result = new DocumentWrapper(uniqueId, builder);
+        }
+      }
+      catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      return result;
+    }
+
+    @Override
+    public boolean hasNext() {
+      try {
+        next = reader.read();
+        return next != null;
+      } catch (IOException e) {
+        return false;
+      }
+    }
   }
 
   private class MyWrapper extends CSVDocumentWrapper {
@@ -207,6 +284,19 @@ public class CSVWithGeoPointBuilder extends CSVDocumentBuilderImpl {
       }
     }
 
+    LatLongHandler(Set<String> latitudeFieldNames, Set<String> longitudeFieldNames, String[] headers) {
+      latOrLongFieldNames = new HashSet<String>(CollectionUtils.union(latitudeFieldNames, longitudeFieldNames));
+
+      for (int i = 0; i < headers.length; i++) {
+        if (latitudeFieldNames.contains(headers[i].toLowerCase())) {
+          lat = i;
+        }
+        if (longitudeFieldNames.contains(headers[i].toLowerCase())) {
+          lon = i;
+        }
+      }
+    }
+
     void addLatLong(XContentBuilder builder, CSVRecord record) throws IOException {
       if (BooleanUtils.or(new boolean[] {lat == -1, lon == -1})) {
         // nothing to do.
@@ -220,6 +310,23 @@ public class CSVWithGeoPointBuilder extends CSVDocumentBuilderImpl {
             Double.parseDouble(latitude), Double.parseDouble(longitude));
       }
       catch (NumberFormatException e) {
+        // Ignore it, no chance of having a location, because the values aren't real latlongs.
+      }
+    }
+
+    void addLatLong(XContentBuilder builder, List<String> row) throws IOException {
+      if (BooleanUtils.or(new boolean[] {lat == -1, lon == -1})) {
+        // nothing to do.
+        return;
+      }
+      String latitude = row.get(lat);
+      String longitude = row.get(lon);
+      try {
+        builder.latlon(
+                getFieldNameMapper().map(locationFieldName()),
+                Double.parseDouble(latitude), Double.parseDouble(longitude));
+      }
+      catch (NumberFormatException | NullPointerException e) {
         // Ignore it, no chance of having a location, because the values aren't real latlongs.
       }
     }

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.NotNull;
  *
  * @config csv-basic-format
  */
+@Deprecated
 @XStreamAlias("csv-basic-format")
 public class BasicFormatBuilder implements FormatBuilder {
 

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
@@ -18,8 +18,8 @@ import javax.validation.constraints.NotNull;
  * TAB DELIMITED} which correspond to the base formats defined by {@link CSVFormat}.
  * </p>
  * <p>
- * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and will eventually
- * be deprecated so that we switch to using a net.supercsv based implementations instead.
+ * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and is now
+ * deprecated so switch to using a net.supercsv based implementations instead.
  * </p>
  *
  * @deprecated Use {@link com.adaptris.csv.BasicPreferenceBuilder} instead.

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
@@ -19,13 +19,13 @@ import javax.validation.constraints.NotNull;
  * </p>
  * <p>
  * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and will eventually
- * be deprecated so that we switch to using a net.supercsv based implementations instead. It is not
- * marked as deprecated just yet.
+ * be deprecated so that we switch to using a net.supercsv based implementations instead.
  * </p>
  *
+ * @deprecated Use {@link com.adaptris.csv.BasicPreferenceBuilder} instead.
  * @config csv-basic-format
  */
-@Deprecated
+@Deprecated(since = "4.1.0")
 @XStreamAlias("csv-basic-format")
 public class BasicFormatBuilder implements FormatBuilder {
 

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
@@ -1,11 +1,12 @@
 package com.adaptris.core.elastic.csv;
 
-import javax.validation.constraints.NotNull;
-import org.apache.commons.csv.CSVFormat;
 import com.adaptris.annotation.AutoPopulated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.csv.CSVFormat;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Implementation of {@link FormatBuilder} that maps the standard commons-csv formats.
@@ -137,5 +138,4 @@ public class BasicFormatBuilder implements FormatBuilder {
   public CSVFormat createFormat() {
     return getStyle().createFormat();
   }
-
 }

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/CustomFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/CustomFormatBuilder.java
@@ -16,8 +16,8 @@ import java.lang.reflect.Method;
  * Implementation of {@link FormatBuilder} that allows for custom csv formats.
  *
  * <p>
- * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and will eventually
- * be deprecated so that we switch to using a net.supercsv based implementations instead.
+ * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and is now
+ * deprecated so switch to using a net.supercsv based implementations instead.
  * </p>
  *
  * @deprecated Use {@link com.adaptris.csv.CustomPreferenceBuilder} instead.

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/CustomFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/CustomFormatBuilder.java
@@ -1,15 +1,16 @@
 package com.adaptris.core.elastic.csv;
 
-import java.lang.reflect.Method;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import lombok.Getter;
-import lombok.Setter;
+
+import java.lang.reflect.Method;
 
 /**
  * Implementation of {@link FormatBuilder} that allows for custom csv formats.
@@ -24,7 +25,8 @@ import lombok.Setter;
  *
  */
 @XStreamAlias("csv-custom-format")
-public class CustomFormatBuilder implements FormatBuilder {
+public class CustomFormatBuilder implements FormatBuilder
+{
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass());
   private static final Character COMMA = Character.valueOf(',');

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/CustomFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/CustomFormatBuilder.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Method;
  * @config csv-custom-format
  *
  */
+@Deprecated
 @XStreamAlias("csv-custom-format")
 public class CustomFormatBuilder implements FormatBuilder
 {

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/CustomFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/CustomFormatBuilder.java
@@ -17,14 +17,13 @@ import java.lang.reflect.Method;
  *
  * <p>
  * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and will eventually
- * be deprecated so that we switch to using a net.supercsv based implementations instead. It is not
- * marked as deprecated just yet.
+ * be deprecated so that we switch to using a net.supercsv based implementations instead.
  * </p>
  *
+ * @deprecated Use {@link com.adaptris.csv.CustomPreferenceBuilder} instead.
  * @config csv-custom-format
- *
  */
-@Deprecated
+@Deprecated(since = "4.1.0")
 @XStreamAlias("csv-custom-format")
 public class CustomFormatBuilder implements FormatBuilder
 {

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/FormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/FormatBuilder.java
@@ -6,8 +6,8 @@ import org.apache.commons.csv.CSVFormat;
  * Builder for creating the required format for parsing the CSV file.
  *
  * <p>
- * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and will eventually
- * be deprecated so that we switch to using a net.supercsv based implementations instead.
+ * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and is now
+ * deprecated so switch to using a net.supercsv based implementations instead.
  * </p>
  *
  * @deprecated Use {@link com.adaptris.csv.PreferenceBuilder} instead.

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/FormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/FormatBuilder.java
@@ -11,6 +11,7 @@ import org.apache.commons.csv.CSVFormat;
  * marked as deprecated just yet.
  * </p>
  */
+@Deprecated
 public interface FormatBuilder
 {
 

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/FormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/FormatBuilder.java
@@ -7,16 +7,17 @@ import org.apache.commons.csv.CSVFormat;
  *
  * <p>
  * Note that this was lifted from the {@code com.adaptris:interlok-csv} project and will eventually
- * be deprecated so that we switch to using a net.supercsv based implementations instead. It is not
- * marked as deprecated just yet.
+ * be deprecated so that we switch to using a net.supercsv based implementations instead.
  * </p>
+ *
+ * @deprecated Use {@link com.adaptris.csv.PreferenceBuilder} instead.
  */
-@Deprecated
+@Deprecated(since = "4.1.0")
 public interface FormatBuilder
 {
 
   /**
-   * Create the CSVFormat Apache Commons CSV.
+   * Create the CSVFormat.
    *
    * @return the CSV Format.
    */

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/FormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/FormatBuilder.java
@@ -11,10 +11,11 @@ import org.apache.commons.csv.CSVFormat;
  * marked as deprecated just yet.
  * </p>
  */
-public interface FormatBuilder {
+public interface FormatBuilder
+{
 
   /**
-   * Create the CSVFormat.
+   * Create the CSVFormat Apache Commons CSV.
    *
    * @return the CSV Format.
    */

--- a/interlok-elastic-common/src/test/java/com/adaptris/core/elastic/CsvGeopointBuilderTest.java
+++ b/interlok-elastic-common/src/test/java/com/adaptris/core/elastic/CsvGeopointBuilderTest.java
@@ -1,19 +1,22 @@
 package com.adaptris.core.elastic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.util.Date;
-import java.util.LinkedHashMap;
-import org.elasticsearch.common.Strings;
-import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.elastic.csv.BasicFormatBuilder;
 import com.adaptris.core.elastic.fields.ToUpperCaseFieldNameMapper;
 import com.adaptris.interlok.util.CloseableIterable;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.ReadContext;
+import org.elasticsearch.common.Strings;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class CsvGeopointBuilderTest extends CsvBuilderCase {
 
@@ -54,13 +57,13 @@ public class CsvGeopointBuilderTest extends CsvBuilderCase {
   @Override
   protected CSVWithGeoPointBuilder createBuilder() {
     return new CSVWithGeoPointBuilder().withLatitudeFieldNames("latitude,lat").withLongitudeFieldNames("longitude,lon")
-        .withLocationFieldName("location");
+        .withLocationFieldName("location").withFormat(new BasicFormatBuilder());
   }
 
   @Test
   public void testBuild_WithTimestamp() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITH_LATLON);
-    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder().withAddTimestampField("My_Timestamp");
+    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder(new BasicFormatBuilder()).withAddTimestampField("My_Timestamp");
     int count = 0;
     try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
       for (DocumentWrapper doc : docs) {
@@ -81,7 +84,7 @@ public class CsvGeopointBuilderTest extends CsvBuilderCase {
   @Test
   public void testBuild_WithLatLong() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITH_LATLON);
-    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder();
+    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder(new BasicFormatBuilder());
     int count = 0;
     try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
       for (DocumentWrapper doc : docs) {
@@ -101,7 +104,7 @@ public class CsvGeopointBuilderTest extends CsvBuilderCase {
   @Test
   public void testBuild_WithLatLongAndMapper() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITH_LATLON);
-    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder();
+    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder(new BasicFormatBuilder());
     documentBuilder.setFieldNameMapper(new ToUpperCaseFieldNameMapper());
     int count = 0;
     try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
@@ -123,7 +126,7 @@ public class CsvGeopointBuilderTest extends CsvBuilderCase {
   public void testBuild_WithCustomLatLong() throws Exception {
     String payload = CSV_WITH_LATLON.replace("latitude", "my_lat").replace("longitude", "my_lon");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
-    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder();
+    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder(new BasicFormatBuilder());
     documentBuilder.setLatitudeFieldNames("My_Lat");
     documentBuilder.setLongitudeFieldNames("My_Lon");
     documentBuilder.setLocationFieldName("My_Location");
@@ -146,7 +149,7 @@ public class CsvGeopointBuilderTest extends CsvBuilderCase {
   @Test
   public void testBuild_WithLatLongAndDelta() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITH_LATLON_AND_DELTA);
-    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder();
+    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder(new BasicFormatBuilder());
     int count = 0;
     try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
       for (DocumentWrapper doc : docs) {
@@ -166,7 +169,7 @@ public class CsvGeopointBuilderTest extends CsvBuilderCase {
   @Test
   public void testBuild_WithoutLatLon() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITHOUT_LATLON);
-    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder();
+    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder(new BasicFormatBuilder());
     int count = 0;
     try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
       for (DocumentWrapper doc : docs) {
@@ -187,7 +190,7 @@ public class CsvGeopointBuilderTest extends CsvBuilderCase {
   @Test
   public void testBuild_WithoutLatLonHeaders() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_NO_LATLON_COLUMNS);
-    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder();
+    CSVWithGeoPointBuilder documentBuilder = new CSVWithGeoPointBuilder(new BasicFormatBuilder());
     int count = 0;
     try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
       for (DocumentWrapper doc : docs) {

--- a/interlok-elastic-common/src/test/java/com/adaptris/core/elastic/SuperCsvDocumentBuilderTest.java
+++ b/interlok-elastic-common/src/test/java/com/adaptris/core/elastic/SuperCsvDocumentBuilderTest.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.elastic;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.elastic.fields.NoOpFieldNameMapper;
+import com.adaptris.csv.BasicPreferenceBuilder;
+import com.adaptris.csv.BasicPreferenceBuilder.Style;
+import com.adaptris.interlok.util.CloseableIterable;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SuperCsvDocumentBuilderTest extends CsvBuilderCase {
+
+  @Override
+  protected CSVDocumentBuilder createBuilder() {
+    return new CSVDocumentBuilder().withUseHeaderRecord(true).withUniqueIdField(0).withAddTimestampField(null)
+        .withFieldNameMapper(new NoOpFieldNameMapper()).withPreferences(new BasicPreferenceBuilder(Style.STANDARD_PREFERENCE));
+  }
+
+  @Test
+  public void testBuild_NoHeaders() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    msg.addMetadata(testName.getMethodName(), testName.getMethodName());
+    CSVDocumentBuilder documentBuilder = createBuilder().withUseHeaderRecord(false);
+    int count = 0;
+    try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
+      for (DocumentWrapper doc : docs) {
+        count++;
+      }
+    }
+    // No headers so the count is the data count + 1
+    assertEquals(6, count);
+  }
+}

--- a/interlok-elastic-common/src/test/java/com/adaptris/core/elastic/SuperCsvGeopointBuilderTest.java
+++ b/interlok-elastic-common/src/test/java/com/adaptris/core/elastic/SuperCsvGeopointBuilderTest.java
@@ -1,0 +1,212 @@
+package com.adaptris.core.elastic;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.elastic.fields.ToUpperCaseFieldNameMapper;
+import com.adaptris.csv.BasicPreferenceBuilder;
+import com.adaptris.csv.BasicPreferenceBuilder.Style;
+import com.adaptris.interlok.util.CloseableIterable;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.ReadContext;
+import org.elasticsearch.common.Strings;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SuperCsvGeopointBuilderTest extends CsvBuilderCase {
+
+  private static final String JSON_LOCATION = "$.location";
+
+  public static final String CSV_WITH_LATLON =
+      "productuniqueid,productname,crop,productcategory,applicationweek,operationdate,manufacturer,applicationrate,measureunit,growthstagecode,iscanonical,latitude,longitude,recordid,id"
+          + System.lineSeparator()
+          + "UID-1,24-D Amine,Passion Fruit,Herbicides,19,20080506,,2.8,Litres per Hectare,,0,53.37969768091292,-0.18346963126415416,210,209"
+          + System.lineSeparator()
+          + "UID-2,26N35S,Rape Winter,Fungicides,12,20150314,,200,Kilograms per Hectare,,0,52.71896363632868,-1.2391368098336788,233,217"
+          + System.lineSeparator();
+
+  public static final String CSV_WITH_LATLON_AND_DELTA =
+      "productuniqueid,productname,crop,productcategory,applicationweek,operationdate,manufacturer,applicationrate,measureunit,growthstagecode,iscanonical,latitude,longitude,recordid,id,delta_status"
+          + System.lineSeparator()
+          + "UID-1,24-D Amine,Passion Fruit,Herbicides,19,20080506,,2.8,Litres per Hectare,,0,53.37969768091292,-0.18346963126415416,210,209,0"
+          + System.lineSeparator()
+          + "UID-2,26N35S,Rape Winter,Fungicides,12,20150314,,200,Kilograms per Hectare,,0,52.71896363632868,-1.2391368098336788,233,217,1"
+          + System.lineSeparator()
+          + "UID-3,26N35S,Rape Winter,Fungicides,12,20150314,,200,Kilograms per Hectare,,0,52.71896363632868,-1.2391368098336788,233,217,2"
+          + System.lineSeparator();
+
+  public static final String CSV_WITHOUT_LATLON =
+      "productuniqueid,productname,crop,productcategory,applicationweek,operationdate,manufacturer,applicationrate,measureunit,growthstagecode,iscanonical,latitude,longitude,recordid,id"
+          + System.lineSeparator() + "UID-1,*A Simazine,,Insecticides,48,20051122,,1.5,Litres per Hectare,,0,,,5,1"
+          + System.lineSeparator() + "UID-2,*Axial,,Herbicides,15,20100408,,0.25,Litres per Hectare,,0,,,6,6"
+          + System.lineSeparator() + "UID-3,*Betanal Maxxim,,Herbicides,18,20130501,,0.07,Litres per Hectare,,0,,,21,21"
+          + System.lineSeparator();
+
+  public static final String CSV_NO_LATLON_COLUMNS =
+      "productuniqueid,productname,crop,productcategory,applicationweek,operationdate,manufacturer,applicationrate,measureunit,growthstagecode,iscanonical,recordid,id"
+          + System.lineSeparator() + "UID-1,*A Simazine,,Insecticides,48,20051122,,1.5,Litres per Hectare,,0,5,1"
+          + System.lineSeparator() + "UID-2,*Axial,,Herbicides,15,20100408,,0.25,Litres per Hectare,,0,6,6" + System.lineSeparator()
+          + "UID-3,*Betanal Maxxim,,Herbicides,18,20130501,,0.07,Litres per Hectare,,0,21,21"
+          + System.lineSeparator();
+
+  @Override
+  protected CSVWithGeoPointBuilder createBuilder() {
+    return new CSVWithGeoPointBuilder(new BasicPreferenceBuilder(Style.STANDARD_PREFERENCE)).withLatitudeFieldNames("latitude,lat").withLongitudeFieldNames("longitude,lon")
+        .withLocationFieldName("location");
+  }
+
+  @Test
+  public void testBuild_WithTimestamp() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITH_LATLON);
+    CSVWithGeoPointBuilder documentBuilder = createBuilder().withAddTimestampField("My_Timestamp");
+    int count = 0;
+    try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
+      for (DocumentWrapper doc : docs) {
+        count++;
+        ReadContext context = parse(Strings.toString(doc.content()));
+        assertEquals("UID-" + count, context.read(JSON_PRODUCTUNIQUEID));
+        assertTrue(Math.abs((Long)context.read("$.My_Timestamp")-new Date().getTime())<50);
+        LinkedHashMap map = context.read(JSON_LOCATION);
+        assertTrue(map.containsKey("lat"));
+        assertFalse("0".equals(map.get("lat").toString()));
+        assertTrue(map.containsKey("lon"));
+        assertFalse("0".equals(map.get("lon").toString()));
+      }
+    }
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testBuild_WithLatLong() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITH_LATLON);
+    CSVWithGeoPointBuilder documentBuilder = createBuilder();
+    int count = 0;
+    try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
+      for (DocumentWrapper doc : docs) {
+        count++;
+        ReadContext context = parse(Strings.toString(doc.content()));
+        assertEquals("UID-" + count, context.read(JSON_PRODUCTUNIQUEID));
+        LinkedHashMap map = context.read(JSON_LOCATION);
+        assertTrue(map.containsKey("lat"));
+        assertFalse("0".equals(map.get("lat").toString()));
+        assertTrue(map.containsKey("lon"));
+        assertFalse("0".equals(map.get("lon").toString()));
+      }
+    }
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testBuild_WithLatLongAndMapper() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITH_LATLON);
+    CSVWithGeoPointBuilder documentBuilder = createBuilder();
+    documentBuilder.setFieldNameMapper(new ToUpperCaseFieldNameMapper());
+    int count = 0;
+    try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
+      for (DocumentWrapper doc : docs) {
+        count++;
+        ReadContext context = parse(Strings.toString(doc.content()));
+        assertEquals("UID-" + count, context.read(JSON_PRODUCTUNIQUEID.toUpperCase()));
+        LinkedHashMap map = context.read(JSON_LOCATION.toUpperCase());
+        assertTrue(map.containsKey("lat"));
+        assertFalse("0".equals(map.get("lat").toString()));
+        assertTrue(map.containsKey("lon"));
+        assertFalse("0".equals(map.get("lon").toString()));
+      }
+    }
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testBuild_WithCustomLatLong() throws Exception {
+    String payload = CSV_WITH_LATLON.replace("latitude", "my_lat").replace("longitude", "my_lon");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
+    CSVWithGeoPointBuilder documentBuilder = createBuilder();
+    documentBuilder.setLatitudeFieldNames("My_Lat");
+    documentBuilder.setLongitudeFieldNames("My_Lon");
+    documentBuilder.setLocationFieldName("My_Location");
+    int count = 0;
+    try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
+      for (DocumentWrapper doc : docs) {
+        count++;
+        ReadContext context = parse(Strings.toString(doc.content()));
+        assertEquals("UID-" + count, context.read(JSON_PRODUCTUNIQUEID));
+        LinkedHashMap map = context.read("$.My_Location");
+        assertTrue(map.containsKey("lat"));
+        assertFalse("0".equals(map.get("lat").toString()));
+        assertTrue(map.containsKey("lon"));
+        assertFalse("0".equals(map.get("lon").toString()));
+      }
+    }
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testBuild_WithLatLongAndDelta() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITH_LATLON_AND_DELTA);
+    CSVWithGeoPointBuilder documentBuilder = createBuilder();
+    int count = 0;
+    try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
+      for (DocumentWrapper doc : docs) {
+        count++;
+        ReadContext context = parse(Strings.toString(doc.content()));
+        assertEquals("UID-" + count, context.read(JSON_PRODUCTUNIQUEID));
+        LinkedHashMap map = context.read(JSON_LOCATION);
+        assertTrue(map.containsKey("lat"));
+        assertFalse("0".equals(map.get("lat").toString()));
+        assertTrue(map.containsKey("lon"));
+        assertFalse("0".equals(map.get("lon").toString()));
+      }
+    }
+    assertEquals(3, count);
+  }
+
+  @Test
+  public void testBuild_WithoutLatLon() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_WITHOUT_LATLON);
+    CSVWithGeoPointBuilder documentBuilder = createBuilder();
+    int count = 0;
+    try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
+      for (DocumentWrapper doc : docs) {
+        count++;
+        ReadContext context = parse(Strings.toString(doc.content()));
+        assertEquals("UID-" + count, context.read("$.productuniqueid"));
+        try {
+          LinkedHashMap map = context.read(JSON_LOCATION);
+          fail();
+        } catch (PathNotFoundException expected) {
+          ;
+        }
+      }
+    }
+    assertEquals(3, count);
+  }
+
+  @Test
+  public void testBuild_WithoutLatLonHeaders() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_NO_LATLON_COLUMNS);
+    CSVWithGeoPointBuilder documentBuilder = createBuilder();
+    int count = 0;
+    try (CloseableIterable<DocumentWrapper> docs = CloseableIterable.ensureCloseable(documentBuilder.build(msg))) {
+      for (DocumentWrapper doc : docs) {
+        count++;
+        ReadContext context = parse(Strings.toString(doc.content()));
+        assertEquals("UID-" + count, context.read("$.productuniqueid"));
+        try {
+          LinkedHashMap map = context.read(JSON_LOCATION);
+          fail();
+        } catch (PathNotFoundException expected) {
+          ;
+        }
+      }
+    }
+    assertEquals(3, count);
+  }
+
+}

--- a/interlok-elastic-rest/src/test/java/com/adaptris/core/elastic/rest/BulkOperationTest.java
+++ b/interlok-elastic-rest/src/test/java/com/adaptris/core/elastic/rest/BulkOperationTest.java
@@ -16,14 +16,6 @@
 
 package com.adaptris.core.elastic.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.common.unit.TimeValue;
-import org.junit.Test;
-import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
@@ -31,8 +23,18 @@ import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.elastic.CSVDocumentBuilder;
 import com.adaptris.core.elastic.SimpleDocumentBuilder;
 import com.adaptris.core.elastic.actions.ConfiguredAction;
+import com.adaptris.csv.BasicPreferenceBuilder;
 import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
 import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.common.unit.TimeValue;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 
 public class BulkOperationTest extends ExampleProducerCase {
 
@@ -166,7 +168,7 @@ public class BulkOperationTest extends ExampleProducerCase {
 
   private BulkOperation createProducerForTests(String action) {
     BulkOperation producer = new BulkOperation().withAction(new ConfiguredAction().withAction(action))
-        .withDocumentBuilder(new CSVDocumentBuilder().withUseHeaderRecord(true))
+        .withDocumentBuilder(new CSVDocumentBuilder(new BasicPreferenceBuilder()).withUseHeaderRecord(true))
         .withRefreshPolicy(null)
             .withIndex("myIndex");
     return producer;


### PR DESCRIPTION
## Motivation

We chose SuperCSV as the CSV implementation to use, which means we needed to migrate the interlok-elastic stuff to using that instead of Apache Common CSV.

## Modification

* Change the CSV builders to have both a FormatBuilder and a PreferenceBuilder
* Deprecate the FormatBuilder stuff
* Add unit tests for PreferenceBuilder

## Result

The end user will need to update their configuration to use PreferenceBuilder instead of FormatBuilder.

## Testing

Thankfully the unit tests were already very extensive, and duplicating the existing builder tests and then switching to use preference instead of format made life easy. A more complete test using a working adapter config would be more beneficial though.