### PR TITLE
Pin to org.elasticsearch:elasticsearch:7.10.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,17 +150,9 @@ subprojects {
     implementation ("commons-collections:commons-collections:3.2.2")
 
     implementation ("org.slf4j:slf4j-api:$slf4jVersion")
-	implementation ("org.apache.logging.log4j:log4j-api:$log4jVersion")
-	
-    implementation ("joda-time:joda-time:2.10.13")
+	  implementation ("org.apache.logging.log4j:log4j-api:$log4jVersion")
 
-    implementation ("org.elasticsearch.client:elasticsearch-rest-high-level-client:$elasticVersion") {
-      exclude group: "org.yaml", module: "snakeyaml"
-    }
-    implementation ("org.elasticsearch.client:elasticsearch-rest-client-sniffer:$elasticVersion") {
-      exclude group: "commons-codec", module: "commons-codec"
-      exclude group: "org.apache.httpcomponents", module: "httpclient"
-    }
+    implementation ("joda-time:joda-time:2.10.13")
 
     implementation ("org.yaml:snakeyaml:1.30")
     implementation ("commons-codec:commons-codec:1.15")
@@ -181,8 +173,8 @@ subprojects {
 
     testImplementation ('junit:junit:4.13.2')
     testImplementation ("org.slf4j:slf4j-simple:$slf4jVersion")
-	testImplementation ("org.apache.logging.log4j:log4j-api:$log4jVersion")
-	
+    testImplementation ("org.apache.logging.log4j:log4j-api:$log4jVersion")
+
     testImplementation ("com.adaptris:interlok-stubs:$interlokCoreVersion") { changing= true }
 
     testImplementation ("org.mockito:mockito-core:$mockitoVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ ext {
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '1.7.35'
   log4jVersion = '2.17.1'
-  elasticVersion = '7.15.1'
   junitJupiterVersion = '5.8.2'
   mockitoVersion = '4.3.1'
 }

--- a/interlok-elastic-common/build.gradle
+++ b/interlok-elastic-common/build.gradle
@@ -2,6 +2,7 @@ ext {
   componentName='Interlok Storage/Elastic: Common'
   componentDesc="Elasticsearch components that are not transport specific"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
+  elasticVersion = '7.10.2'
 }
 
 dependencies {
@@ -11,6 +12,10 @@ dependencies {
   // a bigger deal to remove it out of elastic
   api("org.apache.commons:commons-csv:1.9.0")
   api("net.sf.supercsv:super-csv:2.4.0")
+
+  implementation ("org.elasticsearch:elasticsearch:$elasticVersion") {
+    exclude group: "org.yaml", module: "snakeyaml"
+  }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-elastic-rest/build.gradle
+++ b/interlok-elastic-rest/build.gradle
@@ -2,11 +2,20 @@ ext {
   componentName='Interlok Storage/Elastic: REST Client'
   componentDesc="Producing to Elasticsearch using their REST api"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
+  elasticVersion = '7.10.2'
 }
 
 dependencies {
   api project(':interlok-elastic-common')
   api ("com.adaptris:interlok-apache-http:$interlokCoreVersion") { changing= true}
+
+  implementation ("org.elasticsearch.client:elasticsearch-rest-high-level-client:$elasticVersion") {
+    exclude group: "org.yaml", module: "snakeyaml"
+  }
+  implementation ("org.elasticsearch.client:elasticsearch-rest-client-sniffer:$elasticVersion") {
+    exclude group: "commons-codec", module: "commons-codec"
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
+  }
 
 }
 

--- a/interlok-elastic-rest/src/test/java/com/adaptris/core/elastic/rest/BulkOperationTest.java
+++ b/interlok-elastic-rest/src/test/java/com/adaptris/core/elastic/rest/BulkOperationTest.java
@@ -27,7 +27,7 @@ import com.adaptris.csv.BasicPreferenceBuilder;
 import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
 import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.junit.Test;
 import org.mockito.Mockito;
 

--- a/interlok-elastic-rest/src/test/java/com/adaptris/core/elastic/rest/TransportClientTest.java
+++ b/interlok-elastic-rest/src/test/java/com/adaptris/core/elastic/rest/TransportClientTest.java
@@ -12,7 +12,7 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.sniff.Sniffer;
-import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.junit.Test;
 import org.mockito.Mockito;
 


### PR DESCRIPTION
## Motivation

The motivation is a combination of all these statements.

- Elasticsearch client libraries are forward compatibile so something that uses the 7.10.x library can talk to instances in the 7.10+ range.
    - There's no guarantee that the reverse is true (though in my test installation, I am using elasticsearch-client 7.15 to talk to an elastic-7.8)
- Elasticsearch client 7.16 has changed packages (c.f. https://github.com/adaptris/interlok-elastic/pull/244) for main classes (as opposed to tests).
- Elastic 7.16 makes the Java API GA ready, https://github.com/adaptris/interlok-elastic/issues/252 (no removal date right now)
- The AWS opensearch service offers versions up to 7.10. Elastic says it isn't elastic, but people are going to use it anyway?
- Does this mean that if we follow the elasticsearch jar versions we eventually lose compatibility with AWS Opensearch?

## Modification

- Downgraded to 7.10.2 of the elasticsearch jars
- Force the correct dependency where it's required (interlok-elastic-common no longer has a dependency on high-level-rest-client since it's client agnostic).
- Downgrade the code to be appropriate for 7.10.x (TimeValue in the tests).

## PR Checklist

- [x] been self-reviewed.

## Result

Not entirely sure; there are vulnerabilities reported by `dependencyCheckAnalyze` but they're medium, so I'm willing to ignore them for now. 

- If the user does nothing, then things will continue on working (since 7.10 client can talk to a 7.16 instance) if the user is on the latest.#
- If the user manually upgrades their dependencies to `org.elasticsearch.client:elasticsearch-rest-high-level-client:7.16.3` then things will fail with ClassNotFoundExceptions.

## Testing

You can probably use https://github.com/quotidian-ennui/interlok-speedtest-elastic to do some testing.

__Probably needs a quick chat to see what the best way forward is__
