### PR TITLE
Ignore dependabot branches for codeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,11 @@ name: "CodeQL"
 on:
   push:
     branches: [ develop, master ]
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop ]
+    branches: [ develop ]    
   schedule:
     - cron: '42 12 * * 2'
 


### PR DESCRIPTION
## Motivation

Dependabot runs with readonly tokens, which means it can't run CodeQL analysis

## Modification

Ignore pushes to branches named 'dependabot/**'


