### PR TITLE
Use AsyncHttpClientConfig to configure advanced-elastic-client.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop, master ]
     branches-ignore:
       - 'dependabot/**'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop ]    
+    branches: [ develop ]
   schedule:
     - cron: '42 12 * * 2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
   log4jVersion = '2.17.2'
   junitJupiterVersion = '5.8.2'
   mockitoVersion = '4.4.0'
+  jacksonBomVersion = '2.13.2.20220324'
 }
 
 ext.hasGraphViz = { ->
@@ -129,7 +130,6 @@ subprojects {
     all*.exclude group: 'javax.validation', module: 'validation-api'
     all*.exclude group: 'javax.activation', module: 'activation'
     all*.exclude group: 'javax.activation', module: 'javax.activation-api'
-
     // INTERLOK-3740 switch from jcraft to com.github.mwiede jsch fork.
     all*.exclude group: 'com.jcraft', module: 'jsch'
   }
@@ -149,7 +149,8 @@ subprojects {
     implementation ("commons-collections:commons-collections:3.2.2")
     implementation ("joda-time:joda-time:2.10.14")
     implementation ("org.apache.logging.log4j:log4j-api:$log4jVersion")
-
+    // Use the jackson BOM.
+    implementation ("com.fasterxml.jackson:jackson-bom:$jacksonBomVersion")
     testAnnotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
 
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:$junitJupiterVersion") {

--- a/interlok-elastic-common/build.gradle
+++ b/interlok-elastic-common/build.gradle
@@ -3,7 +3,7 @@ ext {
   componentDesc="Elasticsearch components that are not transport specific"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
   elasticVersion = '7.15.1'
-  jacksonVersion = '2.13.2.20220324'
+  jacksonVersion = '2.13.2.20220328'
 }
 
 dependencies {

--- a/interlok-elastic-common/build.gradle
+++ b/interlok-elastic-common/build.gradle
@@ -3,7 +3,6 @@ ext {
   componentDesc="Elasticsearch components that are not transport specific"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
   elasticVersion = '7.15.1'
-  jacksonVersion = '2.13.2'
 }
 
 dependencies {
@@ -18,10 +17,11 @@ dependencies {
     exclude group: "org.yaml", module: "snakeyaml"
     exclude group: "org.apache.logging.log4j", module:"log4j-api"
   }
-  implementation ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:$jacksonVersion")
-  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
-  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:$jacksonVersion")
+  // Versions derived from the BOM defined in the parent.
+  implementation ("com.fasterxml.jackson.core:jackson-databind")
+  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
+  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-elastic-rest/build.gradle
+++ b/interlok-elastic-rest/build.gradle
@@ -3,7 +3,7 @@ ext {
   componentDesc="Producing to Elasticsearch using their REST api"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
   elasticVersion = '7.15.1'
-  jacksonVersion = '2.13.2.20220324'
+  jacksonVersion = '2.13.2.20220328'
 }
 
 dependencies {

--- a/interlok-elastic-rest/build.gradle
+++ b/interlok-elastic-rest/build.gradle
@@ -7,6 +7,8 @@ ext {
 
 dependencies {
   api project(':interlok-elastic-common')
+  api ("com.adaptris:interlok-apache-http:$interlokCoreVersion") { changing= true}
+  api ("com.adaptris:interlok-apache-http-async:$interlokCoreVersion") { changing= true}
   implementation ("org.elasticsearch.client:elasticsearch-rest-high-level-client:$elasticVersion") {
     exclude group: "org.yaml", module: "snakeyaml"
     exclude group: "org.apache.logging.log4j", module:"log4j-api"
@@ -16,7 +18,6 @@ dependencies {
     exclude group: "org.apache.httpcomponents", module: "httpclient"
     exclude group: "org.apache.logging.log4j", module:"log4j-api"
   }
-  api ("com.adaptris:interlok-apache-http:$interlokCoreVersion") { changing= true}
   implementation ("commons-codec:commons-codec:1.15")
   implementation ("org.apache.httpcomponents:httpclient:4.5.13")
 

--- a/interlok-elastic-rest/build.gradle
+++ b/interlok-elastic-rest/build.gradle
@@ -3,7 +3,6 @@ ext {
   componentDesc="Producing to Elasticsearch using their REST api"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
   elasticVersion = '7.15.1'
-  jacksonVersion = '2.13.2'
 }
 
 dependencies {
@@ -20,10 +19,12 @@ dependencies {
   api ("com.adaptris:interlok-apache-http:$interlokCoreVersion") { changing= true}
   implementation ("commons-codec:commons-codec:1.15")
   implementation ("org.apache.httpcomponents:httpclient:4.5.13")
-  implementation ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:$jacksonVersion")
-  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
-  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:$jacksonVersion")
+
+  // Versions derived from the BOM defined in the parent.
+  implementation ("com.fasterxml.jackson.core:jackson-databind")
+  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
+  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+  implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/AdvancedElasticRestClientCreator.java
+++ b/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/AdvancedElasticRestClientCreator.java
@@ -1,23 +1,24 @@
 package com.adaptris.core.elastic.rest;
 
 import com.adaptris.core.http.apache.request.RequestInterceptorBuilder;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import interlok.http.apache.credentials.CredentialsProviderBuilder;
+import interlok.http.apache.async.AsyncWithInterceptors;
+import interlok.http.apache.async.HttpAsyncClientBuilderConfig;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.validation.Valid;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.elasticsearch.client.RestClientBuilder;
 
-/** Allows you to explicitly control the underlying high level rest client.
- *
+/**
+ * Allows you to explicitly control the underlying high level rest client.
  */
 @XStreamAlias("advanced-elastic-rest-client")
 @NoArgsConstructor
@@ -34,17 +35,23 @@ public class AdvancedElasticRestClientCreator extends ElasticRestClientCreator {
   @XStreamImplicit
   @Getter
   @Setter
+  @Deprecated(since = "4.5.0")
+  @ConfigDeprecated(removalVersion = "5.0.0", message = "Use 'async-http-client-config' instead", groups = Deprecated.class)
   private List<RequestInterceptorBuilder> requestInterceptors;
 
   /**
-   * Customise the underlying Apache {@code HttpClientBuilder} to supply credentials.
+   * Additional configuration required for the underlying REST client.
+   * <p>
+   * This is used to customise the underlying apache {@code CloseableHttpClient} instance used by a {@code RestClient}
+   * instance.
+   * </p>
    */
-  // Since clientCallback uses HttpAsyncClientBuilder which doesn't share a hierarchy with HttpClientBuilder
-  // which sadly means that we can't use HttpClientConfigurator for more fun times.
   @Valid
   @Getter
   @Setter
-  private CredentialsProviderBuilder credentialsProvider;
+  private HttpAsyncClientBuilderConfig asyncHttpClientConfig;
+
+  private transient boolean requestInterceptorWarningLogged = false;
 
   @Override
   public RestClientBuilder configure(RestClientBuilder builder) {
@@ -53,28 +60,39 @@ public class AdvancedElasticRestClientCreator extends ElasticRestClientCreator {
   }
 
   private HttpAsyncClientBuilder configure(HttpAsyncClientBuilder httpBuilder) {
-    requestInterceptors().stream()
-        .forEachOrdered((builder) -> httpBuilder.addInterceptorLast(builder.build()));
-    Optional.ofNullable(getCredentialsProvider())
-        .ifPresent((cp) -> httpBuilder.setDefaultCredentialsProvider(cp.build()));
+    try {
+      builderConfig().configure(httpBuilder);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
     return httpBuilder;
   }
 
-  private List<RequestInterceptorBuilder> requestInterceptors() {
-    return ObjectUtils.defaultIfNull(getRequestInterceptors(), Collections.emptyList());
-  }
-
+  @Deprecated(since="4.5.0")
   public AdvancedElasticRestClientCreator withRequestInterceptors(List<RequestInterceptorBuilder> list) {
     setRequestInterceptors(list);
     return this;
   }
 
+  @Deprecated(since="4.5.0")
   public AdvancedElasticRestClientCreator withRequestInterceptors(RequestInterceptorBuilder... list) {
     return withRequestInterceptors(new ArrayList<>(List.of(list)));
   }
 
-  public AdvancedElasticRestClientCreator withCredentialsProvider(CredentialsProviderBuilder builder) {
-    setCredentialsProvider(builder);
+  public AdvancedElasticRestClientCreator withAsyncClientBuilderConfig(HttpAsyncClientBuilderConfig cfg) {
+    setAsyncHttpClientConfig(cfg);
     return this;
+  }
+
+  private HttpAsyncClientBuilderConfig convertToBuilderConfig(List<RequestInterceptorBuilder> list) {
+    LoggingHelper.logWarning(requestInterceptorWarningLogged, () -> requestInterceptorWarningLogged = true,
+        "Use of request-interceptors is deprecated; switch to a async-http-client-builder instead");
+    return (HttpAsyncClientBuilderConfig) new AsyncWithInterceptors().withInterceptors(list);
+  }
+
+  private HttpAsyncClientBuilderConfig builderConfig() {
+    return Optional.ofNullable(getRequestInterceptors())
+        .map(this::convertToBuilderConfig)
+        .orElse(HttpAsyncClientBuilderConfig.defaultIfNull(this.getAsyncHttpClientConfig()));
   }
 }


### PR DESCRIPTION
## Motivation

Add credential support and resolve https://github.com/adaptris/interlok-elastic/issues/269

Since elastic requires HTTPS when you have credentials; we end up having to configure more of the async-client-builder than just the default credentials.

## Modification

- Switch to using the jackson-bom, since allows us to do the right thing w/o making sure the versions are in line.
- Add dependency on `com.adaptris:interlok-apache-http-async`
- Add a `async-http-client-config` member to AdvancedElasticCreator which allows you to configure more the underlying `HttpAsyncClientBuilder`
- Deprecated the existing request-interceptor configuration since this can be handled by the new config member.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

You can now configure a http-async-client-builder when switching to advanced-elastic-creator

## Testing

You will need a 4.5-SNAPSHOT apache-http + apache-http-async that was built on/after 2022-03-28

Create an elastic-connection, chose advanced-elastic-creator as your client creator and then configure it with a username and password.

Physically testing against elastic (opensource edition) is pretty hard since you need to enable security which means enabling SSL; that's outside the scope of this PR.



