### PR TITLE
INTERLOK-4477: Upgrade jakarta/Update release version to 5.1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ plugins {
 }
 
 ext {
-  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.0-SNAPSHOT'
-  releaseVersion = project.findProperty('releaseVersion') ?: '5.0-SNAPSHOT'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.1-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '5.1-SNAPSHOT'
   nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
   mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"
@@ -133,7 +133,7 @@ subprojects {
     all*.exclude group: 'org.eclipse.jetty.orbit', module: 'javax.mail.glassfish'
     // INTERLOK-3197 exclude old javax.mail
     all*.exclude group: 'com.sun.mail', module: 'javax.mail'
-    all*.exclude group: 'javax.validation', module: 'validation-api'
+    all*.exclude group: 'jakarta.validation', module: 'validation-api'
     all*.exclude group: 'javax.activation', module: 'activation'
     all*.exclude group: 'javax.activation', module: 'javax.activation-api'
     // INTERLOK-3740 switch from jcraft to com.github.mwiede jsch fork.

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilderImpl.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/CSVDocumentBuilderImpl.java
@@ -25,9 +25,9 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/actions/ConfiguredAction.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/actions/ConfiguredAction.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.elastic.actions;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/actions/JsonPathAction.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/actions/JsonPathAction.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.elastic.actions;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import org.elasticsearch.common.Strings;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/actions/MappedAction.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/actions/MappedAction.java
@@ -7,7 +7,7 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.elastic.DocumentWrapper;
 import com.adaptris.util.KeyValuePairList;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/actions/MetadataAction.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/actions/MetadataAction.java
@@ -5,7 +5,7 @@ import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.elastic.DocumentWrapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;

--- a/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
+++ b/interlok-elastic-common/src/main/java/com/adaptris/core/elastic/csv/BasicFormatBuilder.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.csv.CSVFormat;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Implementation of {@link FormatBuilder} that maps the standard commons-csv formats.

--- a/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/AdvancedElasticRestClientCreator.java
+++ b/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/AdvancedElasticRestClientCreator.java
@@ -10,7 +10,7 @@ import interlok.http.apache.async.HttpAsyncClientBuilderConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/BulkOperation.java
+++ b/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/BulkOperation.java
@@ -16,7 +16,7 @@
 
 package com.adaptris.core.elastic.rest;
 
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Min;
 import org.apache.commons.lang3.ObjectUtils;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;

--- a/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/ElasticRestConnection.java
+++ b/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/ElasticRestConnection.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import org.apache.commons.io.IOUtils;
 

--- a/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/ElasticRestProducer.java
+++ b/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/ElasticRestProducer.java
@@ -2,7 +2,7 @@ package com.adaptris.core.elastic.rest;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/SingleOperation.java
+++ b/interlok-elastic-rest/src/main/java/com/adaptris/core/elastic/rest/SingleOperation.java
@@ -16,8 +16,8 @@
 
 package com.adaptris.core.elastic.rest;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.ObjectUtils;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;

--- a/interlok-elastic-sdk/src/main/java/com/adaptris/core/elastic/sdk/connection/ElasticConnection.java
+++ b/interlok-elastic-sdk/src/main/java/com/adaptris/core/elastic/sdk/connection/ElasticConnection.java
@@ -3,9 +3,9 @@ package com.adaptris.core.elastic.sdk.connection;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;

--- a/interlok-elastic-sdk/src/main/java/com/adaptris/core/elastic/sdk/producer/ElasticSdkBulkProducer.java
+++ b/interlok-elastic-sdk/src/main/java/com/adaptris/core/elastic/sdk/producer/ElasticSdkBulkProducer.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.elastic.sdk.producer;
 
-import javax.validation.constraints.Min;
+import jakarta.validation.constraints.Min;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/interlok-elastic-sdk/src/main/java/com/adaptris/core/elastic/sdk/producer/ElasticSdkProducer.java
+++ b/interlok-elastic-sdk/src/main/java/com/adaptris/core/elastic/sdk/producer/ElasticSdkProducer.java
@@ -2,8 +2,8 @@ package com.adaptris.core.elastic.sdk.producer;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.elasticsearch.xcontent.XContentBuilder;


### PR DESCRIPTION
## Motivation

INTERLOK-4477: Upgrade jakarta and jetty, make release version 5.1-SNAPSHOT

## Modification
Updated necessary dependencies and imports to use jakarta instead of javax


## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Compatibility with future versions of jakarta/jetty

## Testing


